### PR TITLE
Support configurable JsonSerializerOptions

### DIFF
--- a/src/Camunda.Worker/Client/ExternalTaskClient.cs
+++ b/src/Camunda.Worker/Client/ExternalTaskClient.cs
@@ -34,6 +34,13 @@ public class ExternalTaskClient : IExternalTaskClient
             });
     }
 
+    public ExternalTaskClient(HttpClient httpClient, Action<JsonSerializerOptions> configureJsonOptions)
+        : this(httpClient)
+    {
+        _jsonSerializerOptions = _jsonSerializerOptions
+            .Also(configureJsonOptions);
+    }
+
     [ExcludeFromCodeCoverage]
     private static void ValidateHttpClient(HttpClient httpClient)
     {

--- a/src/Camunda.Worker/Client/Serialization/JsonVariableJsonConverter.cs
+++ b/src/Camunda.Worker/Client/Serialization/JsonVariableJsonConverter.cs
@@ -23,7 +23,7 @@ public class JsonVariableJsonConverter : JsonConverter<JsonVariable>
     public override void Write(Utf8JsonWriter writer, JsonVariable value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
-        writer.WriteString("value", value.Value.ToJsonString());
+        writer.WriteString("value", value.Value.ToJsonString(options));
         writer.WriteEndObject();
     }
 }

--- a/src/Camunda.Worker/Client/ServiceCollectionExtensions.cs
+++ b/src/Camunda.Worker/Client/ServiceCollectionExtensions.cs
@@ -9,19 +9,18 @@ public static class ServiceCollectionExtensions
 {
     public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services)
     {
-        return services.AddHttpClient<IExternalTaskClient>()
-            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient));
+        return services.AddHttpClient<IExternalTaskClient, ExternalTaskClient>(
+            httpClient => new ExternalTaskClient(httpClient));
     }
 
     public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services, Action<HttpClient> configureClient)
     {
-        return services.AddHttpClient<IExternalTaskClient>(configureClient)
-            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient));
+        return AddExternalTaskClient(services).ConfigureHttpClient(configureClient);
     }
 
     public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services, Action<HttpClient> configureClient, Action<JsonSerializerOptions> configureJsonOptions)
     {
-        return services.AddHttpClient<IExternalTaskClient>(configureClient)
-            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient, configureJsonOptions));
+        return services.AddHttpClient<IExternalTaskClient, ExternalTaskClient>(
+            httpClient => new ExternalTaskClient(httpClient, configureJsonOptions)).ConfigureHttpClient(configureClient);
     }
 }

--- a/src/Camunda.Worker/Client/ServiceCollectionExtensions.cs
+++ b/src/Camunda.Worker/Client/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Camunda.Worker.Client;
@@ -8,11 +9,19 @@ public static class ServiceCollectionExtensions
 {
     public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services)
     {
-        return services.AddHttpClient<IExternalTaskClient, ExternalTaskClient>();
+        return services.AddHttpClient<IExternalTaskClient>()
+            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient));
     }
 
     public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services, Action<HttpClient> configureClient)
     {
-        return services.AddHttpClient<IExternalTaskClient, ExternalTaskClient>(configureClient);
+        return services.AddHttpClient<IExternalTaskClient>(configureClient)
+            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient));
+    }
+
+    public static IHttpClientBuilder AddExternalTaskClient(this IServiceCollection services, Action<HttpClient> configureClient, Action<JsonSerializerOptions> configureJsonOptions)
+    {
+        return services.AddHttpClient<IExternalTaskClient>(configureClient)
+            .AddTypedClient<IExternalTaskClient>(httpClient => new ExternalTaskClient(httpClient, configureJsonOptions));
     }
 }


### PR DESCRIPTION
Hello!
The JSON serialization doesn't seem to support cyrillic or any additional unicode ranges.
For example, the word "Тест" would appear as "\u0422\u0435\u0441\u0442".

I'd like to propose a way to customize the encoder or other JsonSerializerOptions used in the client.